### PR TITLE
update build definition to work for more MSBuild configurations

### DIFF
--- a/build/build.msbuild
+++ b/build/build.msbuild
@@ -4,7 +4,6 @@
       <RootDir>$(MSBuildStartupDirectory)</RootDir>
     </PropertyGroup>
     <UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-
        <ParameterGroup>
            <OutputFilename ParameterType="System.String" Required="true" />
        </ParameterGroup>

--- a/build/build.msbuild
+++ b/build/build.msbuild
@@ -3,7 +3,8 @@
     <PropertyGroup>
       <RootDir>$(MSBuildStartupDirectory)</RootDir>
     </PropertyGroup>
-    <UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v$(MSBuildToolsVersion).dll">
+    <UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyName="Microsoft.Build.Tasks.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+
        <ParameterGroup>
            <OutputFilename ParameterType="System.String" Required="true" />
        </ParameterGroup>

--- a/src/NuGet.Configuration/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Configuration/Properties/AssemblyInfo.cs
@@ -18,7 +18,7 @@ using System.Runtime.CompilerServices;
 [assembly: NeutralResourcesLanguage("en-US")]
 [assembly: CLSCompliant(true)]
 
-[assembly: InternalsVisibleTo("NuGet.Configuration.Test")]
+[assembly: InternalsVisibleTo("NuGet.Configuration.Test", PublicKey = b03f5f7f11d50a3a")]
 
 // When built on the build server, the NuGet release version is specified by the build.
 // When built locally, the NuGet release version is the values specified in this file.


### PR DESCRIPTION
Change the build to look up the Tasks assembly by name rather than location.  It has moved in more recent versions of MS Build.  This approach should be backward compatible.

This PR also has a change to the internals visible to declaration that is required when referencing strong named assemblies.  Not that I get a compile error on the tests saying that the internal constructor is not visible. Not sure what is going on here.
